### PR TITLE
ci: publish legacy required status context for hardening check

### DIFF
--- a/.github/workflows/extension-hardening.yml
+++ b/.github/workflows/extension-hardening.yml
@@ -64,6 +64,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   local-hardening-e2e:
@@ -168,3 +169,28 @@ jobs:
           path: |
             dist/e2e/e2e-long-pagination-*
           if-no-files-found: ignore
+
+      - name: Publish Required Legacy Status Context
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          REQUIRED_STATUS_CONTEXT: Extension Hardening / local-hardening-e2e
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        with:
+          script: |
+            const rawJobStatus = String('${{ job.status }}').toLowerCase();
+            const state = rawJobStatus === 'success'
+              ? 'success'
+              : rawJobStatus === 'cancelled'
+                ? 'error'
+                : 'failure';
+            const description = state === 'success' ? 'Passed' : state === 'error' ? 'Canceled' : 'Failed';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.TARGET_SHA,
+              state,
+              context: process.env.REQUIRED_STATUS_CONTEXT,
+              description,
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });


### PR DESCRIPTION
## Summary
- add statuses: write permission to extension hardening workflow
- publish legacy commit-status context Extension Hardening / local-hardening-e2e via github-script
- prevent future merge blocks where branch protection expects status context instead of check run

## Validation
- workflow syntax reviewed
- this PR itself will verify status context publication on CI run