### PR TITLE
test: harden e2e startup/profile handling across variants

### DIFF
--- a/scripts/e2e-extension-fallback.mjs
+++ b/scripts/e2e-extension-fallback.mjs
@@ -1,6 +1,7 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
+import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
 
 const TARGET_URL = "https://example.com";
 const FALLBACK_COMMAND = String(process.env.E2E_FALLBACK_COMMAND || "maps https://example.com").trim();
@@ -103,14 +104,11 @@ async function waitForFallbackSignal(page, timeoutMs = 90000) {
 
 async function main() {
   const extensionPath = resolve("packages/extension");
-  const userDataDir = resolve(".tmp", "pw-extension-profile-fallback");
+  const userDataDir = createRunProfileDir("fallback");
   const artifactsDir = resolve("dist", "e2e");
 
   if (!KEEP_PROFILE) {
-    await rm(userDataDir, {
-      recursive: true,
-      force: true
-    });
+    await removeDirWithRetries(userDataDir);
   }
   await mkdir(artifactsDir, {
     recursive: true
@@ -123,12 +121,7 @@ async function main() {
   });
 
   try {
-    let serviceWorker = context.serviceWorkers()[0];
-    if (!serviceWorker) {
-      serviceWorker = await context.waitForEvent("serviceworker", {
-        timeout: 20000
-      });
-    }
+    const serviceWorker = await waitForExtensionServiceWorker(context, 60000);
     const extensionId = parseExtensionId(serviceWorker?.url?.());
     assert(extensionId, "Could not resolve extension id");
 
@@ -208,6 +201,13 @@ async function main() {
     console.log(JSON.stringify(result, null, 2));
   } finally {
     await context.close();
+    if (!KEEP_PROFILE) {
+      try {
+        await removeDirWithRetries(userDataDir);
+      } catch {
+        // Non-fatal cleanup errors should not fail the run after assertions completed.
+      }
+    }
   }
 }
 

--- a/scripts/e2e-extension-google-maps.mjs
+++ b/scripts/e2e-extension-google-maps.mjs
@@ -1,6 +1,7 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
+import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
 
 const MAPS_URL =
   "https://www.google.com/maps/search/los+angeles+home+services/@34.1000793,-119.1930544,9z?entry=ttu&g_ep=EgoyMDI2MDIxOC4wIKXMDSoASAFQAw%3D%3D";
@@ -117,13 +118,10 @@ async function patchPermissionApis(page) {
 
 async function main() {
   const extensionPath = resolve("packages/extension");
-  const userDataDir = resolve(".tmp", "pw-extension-profile-maps");
+  const userDataDir = createRunProfileDir("maps");
   const artifactsDir = resolve("dist", "e2e");
   if (!KEEP_PROFILE) {
-    await rm(userDataDir, {
-      recursive: true,
-      force: true
-    });
+    await removeDirWithRetries(userDataDir);
   }
   await mkdir(artifactsDir, {
     recursive: true
@@ -136,12 +134,7 @@ async function main() {
   });
 
   try {
-    let serviceWorker = context.serviceWorkers()[0];
-    if (!serviceWorker) {
-      serviceWorker = await context.waitForEvent("serviceworker", {
-        timeout: 20000
-      });
-    }
+    const serviceWorker = await waitForExtensionServiceWorker(context, 60000);
     const extensionId = parseExtensionId(serviceWorker?.url?.());
     assert(extensionId, "Could not resolve extension id");
 
@@ -233,6 +226,13 @@ async function main() {
     console.log(JSON.stringify(result, null, 2));
   } finally {
     await context.close();
+    if (!KEEP_PROFILE) {
+      try {
+        await removeDirWithRetries(userDataDir);
+      } catch {
+        // Non-fatal cleanup errors should not fail the run after assertions completed.
+      }
+    }
   }
 }
 

--- a/scripts/e2e-extension-long-pagination.mjs
+++ b/scripts/e2e-extension-long-pagination.mjs
@@ -1,7 +1,8 @@
 import { createServer } from "node:http";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
+import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
 
 const KEEP_PROFILE = String(process.env.E2E_KEEP_PROFILE || "").trim() === "1";
 const PATCH_PERMISSIONS = String(process.env.E2E_PATCH_PERMISSIONS || "1").trim() !== "0";
@@ -342,15 +343,12 @@ async function waitForTerminalAndRows(page, timeoutMs = 360000) {
 
 async function main() {
   const extensionPath = resolve("packages/extension");
-  const userDataDir = resolve(".tmp", "pw-extension-profile-long-pagination");
+  const userDataDir = createRunProfileDir("long-pagination");
   const artifactsDir = resolve("dist", "e2e");
   let fixture = null;
 
   if (!KEEP_PROFILE) {
-    await rm(userDataDir, {
-      recursive: true,
-      force: true
-    });
+    await removeDirWithRetries(userDataDir);
   }
   await mkdir(artifactsDir, {
     recursive: true
@@ -367,12 +365,7 @@ async function main() {
   });
 
   try {
-    let serviceWorker = context.serviceWorkers()[0];
-    if (!serviceWorker) {
-      serviceWorker = await context.waitForEvent("serviceworker", {
-        timeout: 20000
-      });
-    }
+    const serviceWorker = await waitForExtensionServiceWorker(context, 60000);
     const extensionId = parseExtensionId(serviceWorker?.url?.());
     assert(extensionId, "Could not resolve extension id");
 
@@ -517,6 +510,13 @@ async function main() {
     console.log(JSON.stringify(result, null, 2));
   } finally {
     await context.close();
+    if (!KEEP_PROFILE) {
+      try {
+        await removeDirWithRetries(userDataDir);
+      } catch {
+        // Non-fatal cleanup errors should not fail the run after assertions completed.
+      }
+    }
     await stopFixtureServer(fixture?.server);
   }
 }

--- a/scripts/e2e-extension-navigate-cycle.mjs
+++ b/scripts/e2e-extension-navigate-cycle.mjs
@@ -1,7 +1,8 @@
 import { createServer } from "node:http";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
+import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
 
 const KEEP_PROFILE = String(process.env.E2E_KEEP_PROFILE || "").trim() === "1";
 const PATCH_PERMISSIONS = String(process.env.E2E_PATCH_PERMISSIONS || "1").trim() !== "0";
@@ -306,15 +307,12 @@ async function waitForTerminalAndRows(page, timeoutMs = 180000) {
 
 async function main() {
   const extensionPath = resolve("packages/extension");
-  const userDataDir = resolve(".tmp", "pw-extension-profile-navigate-cycle");
+  const userDataDir = createRunProfileDir("navigate-cycle");
   const artifactsDir = resolve("dist", "e2e");
   let fixture = null;
 
   if (!KEEP_PROFILE) {
-    await rm(userDataDir, {
-      recursive: true,
-      force: true
-    });
+    await removeDirWithRetries(userDataDir);
   }
   await mkdir(artifactsDir, {
     recursive: true
@@ -331,12 +329,7 @@ async function main() {
   });
 
   try {
-    let serviceWorker = context.serviceWorkers()[0];
-    if (!serviceWorker) {
-      serviceWorker = await context.waitForEvent("serviceworker", {
-        timeout: 20000
-      });
-    }
+    const serviceWorker = await waitForExtensionServiceWorker(context, 60000);
     const extensionId = parseExtensionId(serviceWorker?.url?.());
     assert(extensionId, "Could not resolve extension id");
 
@@ -508,6 +501,13 @@ async function main() {
     console.log(JSON.stringify(result, null, 2));
   } finally {
     await context.close();
+    if (!KEEP_PROFILE) {
+      try {
+        await removeDirWithRetries(userDataDir);
+      } catch {
+        // Non-fatal cleanup errors should not fail the run after assertions completed.
+      }
+    }
     await stopFixtureServer(fixture?.server);
   }
 }

--- a/scripts/e2e-extension-simple.mjs
+++ b/scripts/e2e-extension-simple.mjs
@@ -2,6 +2,7 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { chromium } from "playwright";
+import { waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
 
 const KEEP_PROFILE = String(process.env.E2E_KEEP_PROFILE || "").trim() === "1";
 
@@ -92,12 +93,7 @@ async function main() {
   });
 
   try {
-    let serviceWorker = context.serviceWorkers()[0];
-    if (!serviceWorker) {
-      serviceWorker = await context.waitForEvent("serviceworker", {
-        timeout: 20000
-      });
-    }
+    const serviceWorker = await waitForExtensionServiceWorker(context, 60000);
 
     const extensionId = parseExtensionId(serviceWorker?.url?.());
     assert(extensionId, "Could not resolve extension id from service worker URL");

--- a/scripts/e2e-extension-targeted-results.mjs
+++ b/scripts/e2e-extension-targeted-results.mjs
@@ -1,7 +1,8 @@
 import { createServer } from "node:http";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
+import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
 
 const KEEP_PROFILE = String(process.env.E2E_KEEP_PROFILE || "").trim() === "1";
 const PATCH_PERMISSIONS = String(process.env.E2E_PATCH_PERMISSIONS || "1").trim() !== "0";
@@ -300,15 +301,12 @@ async function waitForTerminalAndRows(page, timeoutMs = 120000) {
 
 async function main() {
   const extensionPath = resolve("packages/extension");
-  const userDataDir = resolve(".tmp", "pw-extension-profile-targeted");
+  const userDataDir = createRunProfileDir("targeted");
   const artifactsDir = resolve("dist", "e2e");
   let fixture = null;
 
   if (!KEEP_PROFILE) {
-    await rm(userDataDir, {
-      recursive: true,
-      force: true
-    });
+    await removeDirWithRetries(userDataDir);
   }
   await mkdir(artifactsDir, {
     recursive: true
@@ -325,12 +323,7 @@ async function main() {
   });
 
   try {
-    let serviceWorker = context.serviceWorkers()[0];
-    if (!serviceWorker) {
-      serviceWorker = await context.waitForEvent("serviceworker", {
-        timeout: 20000
-      });
-    }
+    const serviceWorker = await waitForExtensionServiceWorker(context, 60000);
     const extensionId = parseExtensionId(serviceWorker?.url?.());
     assert(extensionId, "Could not resolve extension id");
 
@@ -458,6 +451,13 @@ async function main() {
     console.log(JSON.stringify(result, null, 2));
   } finally {
     await context.close();
+    if (!KEEP_PROFILE) {
+      try {
+        await removeDirWithRetries(userDataDir);
+      } catch {
+        // Non-fatal cleanup errors should not fail the run after assertions completed.
+      }
+    }
     await stopFixtureServer(fixture?.server);
   }
 }

--- a/scripts/e2e-profile-utils.mjs
+++ b/scripts/e2e-profile-utils.mjs
@@ -1,0 +1,62 @@
+import { rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+export function createRunProfileDir(tag = "e2e") {
+  const safeTag = String(tag || "e2e")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "e2e";
+  const runId = `${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  return resolve(".tmp", `pw-extension-profile-${safeTag}-${runId}`);
+}
+
+export async function removeDirWithRetries(dirPath, attempts = 6) {
+  const totalAttempts = Number.isFinite(Number(attempts)) ? Math.max(1, Number(attempts)) : 6;
+  for (let index = 0; index < totalAttempts; index += 1) {
+    try {
+      await rm(dirPath, {
+        recursive: true,
+        force: true
+      });
+      return;
+    } catch (error) {
+      const code = String(error?.code || "");
+      const canRetry = code === "EBUSY" || code === "EPERM" || code === "ENOTEMPTY";
+      if (!canRetry || index === totalAttempts - 1) {
+        throw error;
+      }
+      await delay(120 * (index + 1));
+    }
+  }
+}
+
+export async function waitForExtensionServiceWorker(context, timeoutMs = 60000) {
+  const deadline = Date.now() + Math.max(1, Number(timeoutMs) || 60000);
+  const existing = context?.serviceWorkers?.()?.[0];
+  if (existing) {
+    return existing;
+  }
+
+  while (Date.now() < deadline) {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    const waitMs = Math.min(5000, remainingMs);
+    try {
+      const serviceWorker = await context.waitForEvent("serviceworker", {
+        timeout: waitMs
+      });
+      if (serviceWorker) {
+        return serviceWorker;
+      }
+    } catch {
+      // Retry until deadline; waitForEvent timeout is expected in sparse startup windows.
+    }
+    const snapshot = context?.serviceWorkers?.()?.[0];
+    if (snapshot) {
+      return snapshot;
+    }
+  }
+
+  throw new Error(`Timed out waiting for extension service worker after ${timeoutMs}ms`);
+}


### PR DESCRIPTION
## Summary
- add shared e2e profile helper (`scripts/e2e-profile-utils.mjs`) for:
  - unique per-run Playwright profile dirs
  - retry-based cleanup for transient Windows locks (`EBUSY`/`EPERM`/`ENOTEMPTY`)
  - resilient extension service-worker discovery with retry/poll windows
- apply helper to all extension e2e variants:
  - simple
  - maps
  - fallback
  - targeted
  - long-pagination
  - navigate-cycle

## Root cause addressed
Two flaky classes were observed in real runs:
1. lockfile contention from fixed profile dirs in overlapping e2e runs
2. intermittent startup timeout while waiting for MV3 service worker (`waitForEvent(serviceworker)` race)

This patch removes shared profile contention and hardens service-worker startup discovery.

## Validation
- `npm run smoke:extension` ✅
- `npm run e2e:extension:simple` ✅
- `npm run e2e:extension:maps` ✅
- `npm run e2e:extension:fallback` ✅
- `npm run e2e:extension:targeted` ✅
- `npm run e2e:extension:long-pagination` ✅
- `npm run e2e:extension:navigate-cycle` ✅