### PR TITLE
refactor: reuse shared e2e profile helpers in simple flow

### DIFF
--- a/scripts/e2e-extension-fallback.mjs
+++ b/scripts/e2e-extension-fallback.mjs
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { chromium } from "playwright";
 import {
   createRunProfileDir,
+  patchPermissionApis,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -17,33 +18,6 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
-}
-
-async function patchPermissionApis(page) {
-  return page.evaluate(() => {
-    if (!globalThis.chrome?.permissions) {
-      return {
-        patched: false,
-        reason: "chrome.permissions unavailable"
-      };
-    }
-    try {
-      globalThis.chrome.permissions.contains = (_details, callback) => {
-        if (typeof callback === "function") callback(true);
-      };
-      globalThis.chrome.permissions.request = (_details, callback) => {
-        if (typeof callback === "function") callback(true);
-      };
-      return {
-        patched: true
-      };
-    } catch (error) {
-      return {
-        patched: false,
-        reason: String(error?.message || error)
-      };
-    }
-  });
 }
 
 async function snapshotUi(page) {

--- a/scripts/e2e-extension-fallback.mjs
+++ b/scripts/e2e-extension-fallback.mjs
@@ -1,7 +1,12 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
-import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
+import {
+  createRunProfileDir,
+  parseExtensionId,
+  removeDirWithRetries,
+  waitForExtensionServiceWorker
+} from "./e2e-profile-utils.mjs";
 
 const TARGET_URL = "https://example.com";
 const FALLBACK_COMMAND = String(process.env.E2E_FALLBACK_COMMAND || "maps https://example.com").trim();
@@ -12,12 +17,6 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
-}
-
-function parseExtensionId(serviceWorkerUrl) {
-  const raw = String(serviceWorkerUrl || "").trim();
-  const match = raw.match(/^chrome-extension:\/\/([^/]+)\//i);
-  return match ? match[1] : "";
 }
 
 async function patchPermissionApis(page) {

--- a/scripts/e2e-extension-google-maps.mjs
+++ b/scripts/e2e-extension-google-maps.mjs
@@ -1,7 +1,12 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
-import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
+import {
+  createRunProfileDir,
+  parseExtensionId,
+  removeDirWithRetries,
+  waitForExtensionServiceWorker
+} from "./e2e-profile-utils.mjs";
 
 const MAPS_URL =
   "https://www.google.com/maps/search/los+angeles+home+services/@34.1000793,-119.1930544,9z?entry=ttu&g_ep=EgoyMDI2MDIxOC4wIKXMDSoASAFQAw%3D%3D";
@@ -12,12 +17,6 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
-}
-
-function parseExtensionId(serviceWorkerUrl) {
-  const raw = String(serviceWorkerUrl || "").trim();
-  const match = raw.match(/^chrome-extension:\/\/([^/]+)\//i);
-  return match ? match[1] : "";
 }
 
 async function snapshotUi(page) {

--- a/scripts/e2e-extension-google-maps.mjs
+++ b/scripts/e2e-extension-google-maps.mjs
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { chromium } from "playwright";
 import {
   createRunProfileDir,
+  patchPermissionApis,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -80,41 +81,6 @@ async function waitForTerminalStatus(page, timeoutMs = 120000) {
   return "timeout";
 }
 
-async function patchPermissionApis(page) {
-  return page.evaluate(() => {
-    if (!globalThis.chrome?.permissions) {
-      return {
-        patched: false,
-        reason: "chrome.permissions unavailable"
-      };
-    }
-    try {
-      const originalContains = globalThis.chrome.permissions.contains;
-      const originalRequest = globalThis.chrome.permissions.request;
-      globalThis.chrome.permissions.contains = (details, callback) => {
-        if (typeof callback === "function") {
-          callback(true);
-        }
-      };
-      globalThis.chrome.permissions.request = (details, callback) => {
-        if (typeof callback === "function") {
-          callback(true);
-        }
-      };
-      return {
-        patched: true,
-        containsChanged: originalContains !== globalThis.chrome.permissions.contains,
-        requestChanged: originalRequest !== globalThis.chrome.permissions.request
-      };
-    } catch (error) {
-      return {
-        patched: false,
-        reason: String(error?.message || error)
-      };
-    }
-  });
-}
-
 async function main() {
   const extensionPath = resolve("packages/extension");
   const userDataDir = createRunProfileDir("maps");
@@ -162,7 +128,9 @@ async function main() {
 
     await panelPage.fill("#start-url", MAPS_URL);
     const patchResult = PATCH_PERMISSIONS
-      ? await patchPermissionApis(panelPage)
+      ? await patchPermissionApis(panelPage, {
+          includeChangeFlags: true
+        })
       : {
           patched: false,
           reason: "disabled"

--- a/scripts/e2e-extension-long-pagination.mjs
+++ b/scripts/e2e-extension-long-pagination.mjs
@@ -5,6 +5,7 @@ import { chromium } from "playwright";
 import {
   createRunProfileDir,
   patchPermissionApis,
+  parseHistoryRowCount,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -227,15 +228,6 @@ async function snapshotUi(page) {
       eventLogTail
     };
   }, { eventTailLimit: EVENT_LOG_TAIL_MAX });
-}
-
-function parseHistoryRowCount(historyText, tableRowCount = 0) {
-  const raw = String(historyText || "");
-  const byPipe = raw.match(/\brows\s+(\d+)\b/i);
-  if (byPipe?.[1]) return Number(byPipe[1]);
-  const byParen = raw.match(/\((\d+)\s+rows\)/i);
-  if (byParen?.[1]) return Number(byParen[1]);
-  return Math.max(0, Number(tableRowCount || 0));
 }
 
 function parseLastTerminationReason(logText = "") {

--- a/scripts/e2e-extension-long-pagination.mjs
+++ b/scripts/e2e-extension-long-pagination.mjs
@@ -2,7 +2,12 @@ import { createServer } from "node:http";
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
-import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
+import {
+  createRunProfileDir,
+  parseExtensionId,
+  removeDirWithRetries,
+  waitForExtensionServiceWorker
+} from "./e2e-profile-utils.mjs";
 
 const KEEP_PROFILE = String(process.env.E2E_KEEP_PROFILE || "").trim() === "1";
 const PATCH_PERMISSIONS = String(process.env.E2E_PATCH_PERMISSIONS || "1").trim() !== "0";
@@ -57,12 +62,6 @@ function parseIntegerEnv(rawValue, { name, min, max, fallback }) {
     throw new Error(`${name} must be in ${min}-${max}, received "${raw}"`);
   }
   return parsed;
-}
-
-function parseExtensionId(serviceWorkerUrl) {
-  const raw = String(serviceWorkerUrl || "").trim();
-  const match = raw.match(/^chrome-extension:\/\/([^/]+)\//i);
-  return match ? match[1] : "";
 }
 
 function buildFixtureHtml(totalRows, batchSize) {

--- a/scripts/e2e-extension-long-pagination.mjs
+++ b/scripts/e2e-extension-long-pagination.mjs
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { chromium } from "playwright";
 import {
   createRunProfileDir,
+  patchPermissionApis,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -192,33 +193,6 @@ async function stopFixtureServer(server) {
   if (!server) return;
   await new Promise((resolve) => {
     server.close(() => resolve());
-  });
-}
-
-async function patchPermissionApis(page) {
-  return page.evaluate(() => {
-    if (!globalThis.chrome?.permissions) {
-      return {
-        patched: false,
-        reason: "chrome.permissions unavailable"
-      };
-    }
-    try {
-      globalThis.chrome.permissions.contains = (_details, callback) => {
-        if (typeof callback === "function") callback(true);
-      };
-      globalThis.chrome.permissions.request = (_details, callback) => {
-        if (typeof callback === "function") callback(true);
-      };
-      return {
-        patched: true
-      };
-    } catch (error) {
-      return {
-        patched: false,
-        reason: String(error?.message || error)
-      };
-    }
   });
 }
 

--- a/scripts/e2e-extension-long-pagination.mjs
+++ b/scripts/e2e-extension-long-pagination.mjs
@@ -4,6 +4,8 @@ import { resolve } from "node:path";
 import { chromium } from "playwright";
 import {
   createRunProfileDir,
+  parseLastLogFieldNumber,
+  parseLastLogFieldString,
   patchPermissionApis,
   parseHistoryRowCount,
   parseIntegerEnv,
@@ -218,31 +220,6 @@ async function snapshotUi(page) {
   }, { eventTailLimit: EVENT_LOG_TAIL_MAX });
 }
 
-function parseLastTerminationReason(logText = "") {
-  const raw = String(logText || "");
-  const pattern = /"terminationReason"\s*:\s*"([^"]+)"/g;
-  let match = null;
-  let last = "";
-  while ((match = pattern.exec(raw)) !== null) {
-    last = String(match[1] || "").trim().toLowerCase();
-  }
-  return last;
-}
-
-function parseLastAutoContinueSegmentsUsed(logText = "") {
-  const raw = String(logText || "");
-  const pattern = /"autoContinueSegmentsUsed"\s*:\s*(\d+)/g;
-  let match = null;
-  let last = 0;
-  while ((match = pattern.exec(raw)) !== null) {
-    const parsed = Number(match[1]);
-    if (Number.isFinite(parsed)) {
-      last = parsed;
-    }
-  }
-  return last;
-}
-
 async function waitForTerminalAndRows(page, timeoutMs = 360000) {
   const deadline = Date.now() + timeoutMs;
   let lastSnapshot = await snapshotUi(page);
@@ -374,8 +351,8 @@ async function main() {
     await panelPage.waitForTimeout(1500);
     const afterRun = await snapshotUi(panelPage);
     const finalRowCount = parseHistoryRowCount(afterRun.selectedHistoryText, afterRun.tableRowCount);
-    const terminationReason = parseLastTerminationReason(afterRun.eventLogTail);
-    const autoContinueSegmentsUsed = parseLastAutoContinueSegmentsUsed(afterRun.eventLogTail);
+    const terminationReason = parseLastLogFieldString(afterRun.eventLogTail, "terminationReason");
+    const autoContinueSegmentsUsed = parseLastLogFieldNumber(afterRun.eventLogTail, "autoContinueSegmentsUsed", 0);
     const hardCapConfigured = /"hardCapAutoContinue"\s*:\s*true/i.test(afterRun.eventLogTail);
 
     await panelPage.screenshot({

--- a/scripts/e2e-extension-long-pagination.mjs
+++ b/scripts/e2e-extension-long-pagination.mjs
@@ -6,6 +6,7 @@ import {
   createRunProfileDir,
   patchPermissionApis,
   parseHistoryRowCount,
+  parseIntegerEnv,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -51,19 +52,6 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
-}
-
-function parseIntegerEnv(rawValue, { name, min, max, fallback }) {
-  const raw = String(rawValue || "").trim();
-  if (!raw) return fallback;
-  if (!/^\d+$/.test(raw)) {
-    throw new Error(`${name} must be an integer in ${min}-${max}, received "${raw}"`);
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
-    throw new Error(`${name} must be in ${min}-${max}, received "${raw}"`);
-  }
-  return parsed;
 }
 
 function buildFixtureHtml(totalRows, batchSize) {

--- a/scripts/e2e-extension-navigate-cycle.mjs
+++ b/scripts/e2e-extension-navigate-cycle.mjs
@@ -5,6 +5,7 @@ import { chromium } from "playwright";
 import {
   createRunProfileDir,
   patchPermissionApis,
+  parseHistoryRowCount,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -46,15 +47,6 @@ function parseIntegerEnv(rawValue, { name, min, max, fallback }) {
     throw new Error(`${name} must be in ${min}-${max}, received "${raw}"`);
   }
   return parsed;
-}
-
-function parseHistoryRowCount(historyText, tableRowCount = 0) {
-  const raw = String(historyText || "");
-  const byPipe = raw.match(/\brows\s+(\d+)\b/i);
-  if (byPipe?.[1]) return Number(byPipe[1]);
-  const byParen = raw.match(/\((\d+)\s+rows\)/i);
-  if (byParen?.[1]) return Number(byParen[1]);
-  return Math.max(0, Number(tableRowCount || 0));
 }
 
 function buildFixtureHtml({ page, pageCount, rowsPerPage }) {

--- a/scripts/e2e-extension-navigate-cycle.mjs
+++ b/scripts/e2e-extension-navigate-cycle.mjs
@@ -4,6 +4,8 @@ import { resolve } from "node:path";
 import { chromium } from "playwright";
 import {
   createRunProfileDir,
+  parseLastLogFieldNumber,
+  parseLastLogFieldString,
   patchPermissionApis,
   parseHistoryRowCount,
   parseIntegerEnv,
@@ -180,31 +182,6 @@ async function snapshotUi(page) {
   }, { eventTailLimit: EVENT_LOG_TAIL_MAX });
 }
 
-function parseLastTerminationReason(logText = "") {
-  const raw = String(logText || "");
-  const pattern = /"terminationReason"\s*:\s*"([^"]+)"/g;
-  let match = null;
-  let last = "";
-  while ((match = pattern.exec(raw)) !== null) {
-    last = String(match[1] || "").trim().toLowerCase();
-  }
-  return last;
-}
-
-function parseLastVisitedNavigationUrlCount(logText = "") {
-  const raw = String(logText || "");
-  const pattern = /"visitedNavigationUrlCount"\s*:\s*(\d+)/g;
-  let match = null;
-  let last = 0;
-  while ((match = pattern.exec(raw)) !== null) {
-    const parsed = Number(match[1]);
-    if (Number.isFinite(parsed)) {
-      last = parsed;
-    }
-  }
-  return last;
-}
-
 async function waitForAutoDetect(page, timeoutMs = 25000) {
   const deadline = Date.now() + timeoutMs;
   let lastStatus = "";
@@ -360,8 +337,8 @@ async function main() {
     await panelPage.waitForTimeout(1200);
     const afterRun = await snapshotUi(panelPage);
     const finalRowCount = parseHistoryRowCount(afterRun.selectedHistoryText, afterRun.tableRowCount);
-    const terminationReason = parseLastTerminationReason(afterRun.eventLogTail);
-    const visitedNavigationUrlCount = parseLastVisitedNavigationUrlCount(afterRun.eventLogTail);
+    const terminationReason = parseLastLogFieldString(afterRun.eventLogTail, "terminationReason");
+    const visitedNavigationUrlCount = parseLastLogFieldNumber(afterRun.eventLogTail, "visitedNavigationUrlCount", 0);
 
     await panelPage.screenshot({
       path: resolve(artifactsDir, "e2e-navigate-cycle-sidepanel.png"),

--- a/scripts/e2e-extension-navigate-cycle.mjs
+++ b/scripts/e2e-extension-navigate-cycle.mjs
@@ -2,7 +2,12 @@ import { createServer } from "node:http";
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
-import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
+import {
+  createRunProfileDir,
+  parseExtensionId,
+  removeDirWithRetries,
+  waitForExtensionServiceWorker
+} from "./e2e-profile-utils.mjs";
 
 const KEEP_PROFILE = String(process.env.E2E_KEEP_PROFILE || "").trim() === "1";
 const PATCH_PERMISSIONS = String(process.env.E2E_PATCH_PERMISSIONS || "1").trim() !== "0";
@@ -40,12 +45,6 @@ function parseIntegerEnv(rawValue, { name, min, max, fallback }) {
     throw new Error(`${name} must be in ${min}-${max}, received "${raw}"`);
   }
   return parsed;
-}
-
-function parseExtensionId(serviceWorkerUrl) {
-  const raw = String(serviceWorkerUrl || "").trim();
-  const match = raw.match(/^chrome-extension:\/\/([^/]+)\//i);
-  return match ? match[1] : "";
 }
 
 function parseHistoryRowCount(historyText, tableRowCount = 0) {

--- a/scripts/e2e-extension-navigate-cycle.mjs
+++ b/scripts/e2e-extension-navigate-cycle.mjs
@@ -6,6 +6,7 @@ import {
   createRunProfileDir,
   patchPermissionApis,
   parseHistoryRowCount,
+  parseIntegerEnv,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -34,19 +35,6 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
-}
-
-function parseIntegerEnv(rawValue, { name, min, max, fallback }) {
-  const raw = String(rawValue || "").trim();
-  if (!raw) return fallback;
-  if (!/^\d+$/.test(raw)) {
-    throw new Error(`${name} must be an integer in ${min}-${max}, received "${raw}"`);
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
-    throw new Error(`${name} must be in ${min}-${max}, received "${raw}"`);
-  }
-  return parsed;
 }
 
 function buildFixtureHtml({ page, pageCount, rowsPerPage }) {

--- a/scripts/e2e-extension-navigate-cycle.mjs
+++ b/scripts/e2e-extension-navigate-cycle.mjs
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { chromium } from "playwright";
 import {
   createRunProfileDir,
+  patchPermissionApis,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -163,33 +164,6 @@ async function stopFixtureServer(server) {
   if (!server) return;
   await new Promise((resolve) => {
     server.close(() => resolve());
-  });
-}
-
-async function patchPermissionApis(page) {
-  return page.evaluate(() => {
-    if (!globalThis.chrome?.permissions) {
-      return {
-        patched: false,
-        reason: "chrome.permissions unavailable"
-      };
-    }
-    try {
-      globalThis.chrome.permissions.contains = (_details, callback) => {
-        if (typeof callback === "function") callback(true);
-      };
-      globalThis.chrome.permissions.request = (_details, callback) => {
-        if (typeof callback === "function") callback(true);
-      };
-      return {
-        patched: true
-      };
-    } catch (error) {
-      return {
-        patched: false,
-        reason: String(error?.message || error)
-      };
-    }
   });
 }
 

--- a/scripts/e2e-extension-simple.mjs
+++ b/scripts/e2e-extension-simple.mjs
@@ -1,8 +1,11 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { setTimeout as delay } from "node:timers/promises";
 import { chromium } from "playwright";
-import { waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
+import {
+  createRunProfileDir,
+  removeDirWithRetries,
+  waitForExtensionServiceWorker
+} from "./e2e-profile-utils.mjs";
 
 const KEEP_PROFILE = String(process.env.E2E_KEEP_PROFILE || "").trim() === "1";
 
@@ -16,30 +19,6 @@ function parseExtensionId(serviceWorkerUrl) {
   const raw = String(serviceWorkerUrl || "").trim();
   const match = raw.match(/^chrome-extension:\/\/([^/]+)\//i);
   return match ? match[1] : "";
-}
-
-function createRunProfileDir() {
-  const runId = `${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
-  return resolve(".tmp", `pw-extension-profile-simple-${runId}`);
-}
-
-async function removeDirWithRetries(dirPath, attempts = 6) {
-  for (let index = 0; index < attempts; index += 1) {
-    try {
-      await rm(dirPath, {
-        recursive: true,
-        force: true
-      });
-      return;
-    } catch (error) {
-      const code = String(error?.code || "");
-      const canRetry = code === "EBUSY" || code === "EPERM" || code === "ENOTEMPTY";
-      if (!canRetry || index === attempts - 1) {
-        throw error;
-      }
-      await delay(120 * (index + 1));
-    }
-  }
 }
 
 async function readUiState(page) {

--- a/scripts/e2e-extension-simple.mjs
+++ b/scripts/e2e-extension-simple.mjs
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { chromium } from "playwright";
 import {
   createRunProfileDir,
+  parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
 } from "./e2e-profile-utils.mjs";
@@ -13,12 +14,6 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
-}
-
-function parseExtensionId(serviceWorkerUrl) {
-  const raw = String(serviceWorkerUrl || "").trim();
-  const match = raw.match(/^chrome-extension:\/\/([^/]+)\//i);
-  return match ? match[1] : "";
 }
 
 async function readUiState(page) {

--- a/scripts/e2e-extension-targeted-results.mjs
+++ b/scripts/e2e-extension-targeted-results.mjs
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { chromium } from "playwright";
 import {
   createRunProfileDir,
+  patchPermissionApis,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -177,33 +178,6 @@ async function stopFixtureServer(server) {
   if (!server) return;
   await new Promise((resolve) => {
     server.close(() => resolve());
-  });
-}
-
-async function patchPermissionApis(page) {
-  return page.evaluate(() => {
-    if (!globalThis.chrome?.permissions) {
-      return {
-        patched: false,
-        reason: "chrome.permissions unavailable"
-      };
-    }
-    try {
-      globalThis.chrome.permissions.contains = (_details, callback) => {
-        if (typeof callback === "function") callback(true);
-      };
-      globalThis.chrome.permissions.request = (_details, callback) => {
-        if (typeof callback === "function") callback(true);
-      };
-      return {
-        patched: true
-      };
-    } catch (error) {
-      return {
-        patched: false,
-        reason: String(error?.message || error)
-      };
-    }
   });
 }
 

--- a/scripts/e2e-extension-targeted-results.mjs
+++ b/scripts/e2e-extension-targeted-results.mjs
@@ -2,7 +2,12 @@ import { createServer } from "node:http";
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
-import { createRunProfileDir, removeDirWithRetries, waitForExtensionServiceWorker } from "./e2e-profile-utils.mjs";
+import {
+  createRunProfileDir,
+  parseExtensionId,
+  removeDirWithRetries,
+  waitForExtensionServiceWorker
+} from "./e2e-profile-utils.mjs";
 
 const KEEP_PROFILE = String(process.env.E2E_KEEP_PROFILE || "").trim() === "1";
 const PATCH_PERMISSIONS = String(process.env.E2E_PATCH_PERMISSIONS || "1").trim() !== "0";
@@ -21,12 +26,6 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
-}
-
-function parseExtensionId(serviceWorkerUrl) {
-  const raw = String(serviceWorkerUrl || "").trim();
-  const match = raw.match(/^chrome-extension:\/\/([^/]+)\//i);
-  return match ? match[1] : "";
 }
 
 function parseTargetResultsFromEnv(rawValue) {

--- a/scripts/e2e-extension-targeted-results.mjs
+++ b/scripts/e2e-extension-targeted-results.mjs
@@ -5,6 +5,7 @@ import { chromium } from "playwright";
 import {
   createRunProfileDir,
   patchPermissionApis,
+  parseHistoryRowCount,
   parseExtensionId,
   removeDirWithRetries,
   waitForExtensionServiceWorker
@@ -226,15 +227,6 @@ async function waitForEventLogSignal(page, signal, timeoutMs = EVENT_LOG_SIGNAL_
     await page.waitForTimeout(EVENT_LOG_POLL_INTERVAL_MS);
   }
   return false;
-}
-
-function parseHistoryRowCount(historyText, tableRowCount = 0) {
-  const raw = String(historyText || "");
-  const byPipe = raw.match(/\brows\s+(\d+)\b/i);
-  if (byPipe?.[1]) return Number(byPipe[1]);
-  const byParen = raw.match(/\((\d+)\s+rows\)/i);
-  if (byParen?.[1]) return Number(byParen[1]);
-  return Math.max(0, Number(tableRowCount || 0));
 }
 
 async function waitForTerminalAndRows(page, timeoutMs = 120000) {

--- a/scripts/e2e-profile-utils.mjs
+++ b/scripts/e2e-profile-utils.mjs
@@ -18,6 +18,41 @@ export function parseExtensionId(serviceWorkerUrl) {
   return match ? match[1] : "";
 }
 
+export async function patchPermissionApis(page, options = {}) {
+  const includeChangeFlags = Boolean(options?.includeChangeFlags);
+  return page.evaluate(({ includeChangeFlags: includeFlags }) => {
+    if (!globalThis.chrome?.permissions) {
+      return {
+        patched: false,
+        reason: "chrome.permissions unavailable"
+      };
+    }
+    try {
+      const originalContains = globalThis.chrome.permissions.contains;
+      const originalRequest = globalThis.chrome.permissions.request;
+      globalThis.chrome.permissions.contains = (_details, callback) => {
+        if (typeof callback === "function") callback(true);
+      };
+      globalThis.chrome.permissions.request = (_details, callback) => {
+        if (typeof callback === "function") callback(true);
+      };
+      const result = {
+        patched: true
+      };
+      if (includeFlags) {
+        result.containsChanged = originalContains !== globalThis.chrome.permissions.contains;
+        result.requestChanged = originalRequest !== globalThis.chrome.permissions.request;
+      }
+      return result;
+    } catch (error) {
+      return {
+        patched: false,
+        reason: String(error?.message || error)
+      };
+    }
+  }, { includeChangeFlags });
+}
+
 export async function removeDirWithRetries(dirPath, attempts = 6) {
   const totalAttempts = Number.isFinite(Number(attempts)) ? Math.max(1, Number(attempts)) : 6;
   for (let index = 0; index < totalAttempts; index += 1) {

--- a/scripts/e2e-profile-utils.mjs
+++ b/scripts/e2e-profile-utils.mjs
@@ -75,6 +75,35 @@ export function parseIntegerEnv(rawValue, { name, min, max, fallback }) {
   return parsed;
 }
 
+export function parseLastLogFieldString(logText = "", fieldName = "") {
+  const field = String(fieldName || "").trim();
+  if (!field) return "";
+  const raw = String(logText || "");
+  const pattern = new RegExp(`"${field}"\\s*:\\s*"([^"]+)"`, "g");
+  let match = null;
+  let last = "";
+  while ((match = pattern.exec(raw)) !== null) {
+    last = String(match[1] || "").trim().toLowerCase();
+  }
+  return last;
+}
+
+export function parseLastLogFieldNumber(logText = "", fieldName = "", fallback = 0) {
+  const field = String(fieldName || "").trim();
+  if (!field) return fallback;
+  const raw = String(logText || "");
+  const pattern = new RegExp(`"${field}"\\s*:\\s*(\\d+)`, "g");
+  let match = null;
+  let last = fallback;
+  while ((match = pattern.exec(raw)) !== null) {
+    const parsed = Number(match[1]);
+    if (Number.isFinite(parsed)) {
+      last = parsed;
+    }
+  }
+  return last;
+}
+
 export async function removeDirWithRetries(dirPath, attempts = 6) {
   const totalAttempts = Number.isFinite(Number(attempts)) ? Math.max(1, Number(attempts)) : 6;
   for (let index = 0; index < totalAttempts; index += 1) {

--- a/scripts/e2e-profile-utils.mjs
+++ b/scripts/e2e-profile-utils.mjs
@@ -12,6 +12,12 @@ export function createRunProfileDir(tag = "e2e") {
   return resolve(".tmp", `pw-extension-profile-${safeTag}-${runId}`);
 }
 
+export function parseExtensionId(serviceWorkerUrl) {
+  const raw = String(serviceWorkerUrl || "").trim();
+  const match = raw.match(/^chrome-extension:\/\/([^/]+)\//i);
+  return match ? match[1] : "";
+}
+
 export async function removeDirWithRetries(dirPath, attempts = 6) {
   const totalAttempts = Number.isFinite(Number(attempts)) ? Math.max(1, Number(attempts)) : 6;
   for (let index = 0; index < totalAttempts; index += 1) {

--- a/scripts/e2e-profile-utils.mjs
+++ b/scripts/e2e-profile-utils.mjs
@@ -62,6 +62,19 @@ export function parseHistoryRowCount(historyText, tableRowCount = 0) {
   return Math.max(0, Number(tableRowCount || 0));
 }
 
+export function parseIntegerEnv(rawValue, { name, min, max, fallback }) {
+  const raw = String(rawValue || "").trim();
+  if (!raw) return fallback;
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`${name} must be an integer in ${min}-${max}, received "${raw}"`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${name} must be in ${min}-${max}, received "${raw}"`);
+  }
+  return parsed;
+}
+
 export async function removeDirWithRetries(dirPath, attempts = 6) {
   const totalAttempts = Number.isFinite(Number(attempts)) ? Math.max(1, Number(attempts)) : 6;
   for (let index = 0; index < totalAttempts; index += 1) {

--- a/scripts/e2e-profile-utils.mjs
+++ b/scripts/e2e-profile-utils.mjs
@@ -53,6 +53,15 @@ export async function patchPermissionApis(page, options = {}) {
   }, { includeChangeFlags });
 }
 
+export function parseHistoryRowCount(historyText, tableRowCount = 0) {
+  const raw = String(historyText || "");
+  const byPipe = raw.match(/\brows\s+(\d+)\b/i);
+  if (byPipe?.[1]) return Number(byPipe[1]);
+  const byParen = raw.match(/\((\d+)\s+rows\)/i);
+  if (byParen?.[1]) return Number(byParen[1]);
+  return Math.max(0, Number(tableRowCount || 0));
+}
+
 export async function removeDirWithRetries(dirPath, attempts = 6) {
   const totalAttempts = Number.isFinite(Number(attempts)) ? Math.max(1, Number(attempts)) : 6;
   for (let index = 0; index < totalAttempts; index += 1) {


### PR DESCRIPTION
## Summary
- remove duplicated profile-dir cleanup helpers from scripts/e2e-extension-simple.mjs
- import and use shared createRunProfileDir, emoveDirWithRetries, and waitForExtensionServiceWorker from scripts/e2e-profile-utils.mjs
- keep behavior unchanged while reducing script-specific retry logic drift

## Validation
- npm run test:local:hardening:e2e
- npm run hardening:railway:e2e
- npm run release:extension